### PR TITLE
Forward Declaration of QSyntaxHighlighter is meaningless

### DIFF
--- a/src/gui/terminalwidget/outpaneltext.h
+++ b/src/gui/terminalwidget/outpaneltext.h
@@ -47,8 +47,6 @@ class MAINMODULE_EXPORT OutPanelText : public QPlainTextEdit
 
 // CLASS OutHighlighter ****************************************
 
-class QSyntaxHighlighter;
-
 class OutHighlighter : public QSyntaxHighlighter
 {
     Q_OBJECT


### PR DESCRIPTION
`class QSyntaxHighlighter;`

This Forward Declaration of QSyntaxHighlighter ~is~should have been incorrect because [~Forward Declarations~Incomplete Types cannot be used as Base Class](https://stackoverflow.com/a/553869/1691072)

However, by including the QSyntaxHighlighter Header, the complete type was available.  
As a result, the Forward Declaration is in a way, meaningless and so should be removed from the codebase

Thanks to @erichkeane for asking me to issue a more accurate clarification as to the reasoning behind the change and my apologies for not sticking to the language legalese (because this code is correct, but the line is meaningless) about what the cause of this issue was.

And yes, @erichkeane is right. It's not at all a syntactically incorrect or programmatically incorrect code, so my title could have been different and I do apologise, it is just meaningless.

~Also the File `#include <QSyntaxHighlighter>` so it anyways looks pointless to me.  
Could explain why an error isn't thrown in this case as by including QSyntaxHighlighter, the declaration of QSyntaxHighlighter is already available~

Full Disclosure:-
Came across it while I was reading the code so haven't had the opportunity to test it
(Got here from https://www.reddit.com/r/cpp/comments/j2uwoa/hacktoberfest_we_need_c_and_qt_developers_for_the/)