### PR TITLE
Trigger Build Action on Pull Request

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,6 +1,6 @@
 name: Build
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
On my last pull request, I noticed that GitHub Actions were not running in Pull Request page, only in my fork

Example:- https://github.com/SimulIDE/SimulIDE/pull/15. The fork has the action triggered but we don't necessarily see the results in the commit the way you can see them here